### PR TITLE
Add support for Cursor (and other VS Code < 1.120 hosts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.1",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.53.0",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "@typescript-eslint/parser": "^8.60.1",
         "@vscode/test-electron": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@types/glob": "^9.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.1",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.53.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",
     "@vscode/test-electron": "^2.5.2",

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
-import * as Mocha from 'mocha';
-import * as glob from 'glob';
+import Mocha from 'mocha';
+import { glob } from 'glob';
 
 export function run(): Promise<void> {
 	// Create the mocha test
@@ -12,11 +12,7 @@ export function run(): Promise<void> {
 	const testsRoot = path.resolve(__dirname, '..');
 
 	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-			if (err) {
-				return e(err);
-			}
-
+		glob('**/**.test.js', { cwd: testsRoot }).then(files => {
 			// Add files to the test suite
 			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
 
@@ -33,6 +29,6 @@ export function run(): Promise<void> {
 				console.error(err);
 				e(err);
 			}
-		});
+		}, e);
 	});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
                 "sourceMap": true,
                 "rootDir": "src",
                 "newLine": "lf",
+                "skipLibCheck": true,
                 "strict": true   /* enable all strict type-checking options */
                 /* Additional Checks */
                 // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
Cursor's bundled VS Code base (e.g. 1.105.1) is older than 1.120, so the extension failed to install with "not compatible with VS Code '1.105.1'". The @types/vscode bump to 1.120.0 had forced engines.vscode up to a floor no Cursor build satisfies, even though the code only uses APIs from 1.53.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
